### PR TITLE
Trial index logging for playback alignment

### DIFF
--- a/examples/rig.py
+++ b/examples/rig.py
@@ -86,7 +86,7 @@ rig = UclOpenVrCorridor2pRig(
         location_y=-1
     ),
     arduino=MatrixArduino(
-        port_name="COM10",
+        port_name="COM3",
         baud_rate=1000000,
         new_line="\n"
     ),
@@ -94,7 +94,7 @@ rig = UclOpenVrCorridor2pRig(
     quad_time_upper_bound=0.5,
     # movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
     #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/Users/neurogears/source/repos/ucl-open/vr-corridor-2p/temp_data/sub-Plimbo/ses-PlaybackTest_date-2026-04-16T11-49-15/RenderFrameCount/RenderFrameCount.csv", position_index=4, trial_index_index=5)
+    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-M26005/20260416/ses-M26005_BaselineCorridor_20260416_00001_date-2026-04-16T13-05-41/RenderFrameCount/RenderFrameCount.csv", position_index=4, trial_index_index=5)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -86,7 +86,7 @@ rig = UclOpenVrCorridor2pRig(
         location_y=-1
     ),
     arduino=MatrixArduino(
-        port_name="COM3",
+        port_name="COM10",
         baud_rate=1000000,
         new_line="\n"
     ),

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -92,9 +92,9 @@ rig = UclOpenVrCorridor2pRig(
     ),
     quad_time_lower_bound=0.2,
     quad_time_upper_bound=0.5,
-    #movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
+    movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
     #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-Plimbo/20260415/ses-Plimbo_BaselineCorridor_CL_20260415_date-2026-04-15T09-47-25/RenderFrameCount/RenderFrameCount.csv", index=4)
+    # movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-Plimbo/20260415/ses-Plimbo_BaselineCorridor_CL_20260415_date-2026-04-15T09-47-25/RenderFrameCount/RenderFrameCount.csv", index=4)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -93,8 +93,8 @@ rig = UclOpenVrCorridor2pRig(
     quad_time_lower_bound=0.2,
     quad_time_upper_bound=0.5,
     #movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
-    #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/CODE/BONSAI/vr-corridor-2p/temp_data/sub-PlaybackTest/ses-PlaybackTest_date-2026-04-13T10-57-27/RenderFrameCount/RenderFrameCount.csv", index=4)
+    movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
+    #movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/CODE/BONSAI/vr-corridor-2p/temp_data/sub-PlaybackTest/ses-PlaybackTest_date-2026-04-13T10-57-27/RenderFrameCount/RenderFrameCount.csv", index=4)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -94,7 +94,7 @@ rig = UclOpenVrCorridor2pRig(
     quad_time_upper_bound=0.5,
     #movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
     #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-M25131/20260414/ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-14-10/RenderFrameCount/RenderFrameCount.csv", index=4)
+    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-Plimbo/20260415/ses-Plimbo_BaselineCorridor_CL_20260415_date-2026-04-15T09-47-25/RenderFrameCount/RenderFrameCount.csv", index=4)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -94,7 +94,7 @@ rig = UclOpenVrCorridor2pRig(
     quad_time_upper_bound=0.5,
     # movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
     #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-M26005/20260416/ses-M26005_BaselineCorridor_20260416_00001_date-2026-04-16T13-05-41/RenderFrameCount/RenderFrameCount.csv", position_index=4, trial_index_index=5)
+    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-M26005/20260417/ses-M26005_BaselineCorridor_20260417_00001_date-2026-04-17T08-31-21/RenderFrameCount/RenderFrameCount.csv", position_index=4, trial_index_index=5)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -92,9 +92,9 @@ rig = UclOpenVrCorridor2pRig(
     ),
     quad_time_lower_bound=0.2,
     quad_time_upper_bound=0.5,
-    movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
+    # movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
     #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    # movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-Plimbo/20260415/ses-Plimbo_BaselineCorridor_CL_20260415_date-2026-04-15T09-47-25/RenderFrameCount/RenderFrameCount.csv", index=4)
+    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/Users/neurogears/source/repos/ucl-open/vr-corridor-2p/temp_data/sub-Plimbo/ses-PlaybackTest_date-2026-04-16T11-49-15/RenderFrameCount/RenderFrameCount.csv", position_index=4, trial_index_index=5)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/rig.py
+++ b/examples/rig.py
@@ -93,8 +93,8 @@ rig = UclOpenVrCorridor2pRig(
     quad_time_lower_bound=0.2,
     quad_time_upper_bound=0.5,
     #movement_source=MouseWheelMovementSource(source_type="mouse_wheel", gain=0.1) # computer mouse wheel
-    movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
-    #movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/CODE/BONSAI/vr-corridor-2p/temp_data/sub-PlaybackTest/ses-PlaybackTest_date-2026-04-13T10-57-27/RenderFrameCount/RenderFrameCount.csv", index=4)
+    #movement_source=SensorMovementSource(source_type="sensor_movement") # encoder 
+    movement_source=PlaybackMovementSource(source_type="playback", file_path="C:/UCLOpenDATA/sub-M25131/20260414/ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-14-10/RenderFrameCount/RenderFrameCount.csv", index=4)
 )
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/session.py
+++ b/examples/session.py
@@ -8,10 +8,10 @@ session = UclOpenSession(
     workflow="main.bonsai",
     commit="",
     repository_url="https://github.com/ucl-open/vr-corridor-2p",
-    #logging_root_path="../temp_data",
-    logging_root_path="C:/UCLOpenDATA/",
-    animal_id="Plimbo/20260415/",
-    session_id="Plimbo_BaselineCorridor_OL_20260415" 
+    logging_root_path="../temp_data",
+    # logging_root_path="C:/UCLOpenDATA/",
+    animal_id="Plimbo",
+    session_id="PlaybackTest" 
 )   
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/session.py
+++ b/examples/session.py
@@ -8,10 +8,10 @@ session = UclOpenSession(
     workflow="main.bonsai",
     commit="",
     repository_url="https://github.com/ucl-open/vr-corridor-2p",
-    logging_root_path="../temp_data",
-    # logging_root_path="C:/UCLOpenDATA/",
-    animal_id="Plimbo",
-    session_id="PlaybackTest" 
+    #logging_root_path="../temp_data",
+    logging_root_path="C:/UCLOpenDATA/",
+    animal_id="M26005/20260416/",
+    session_id="M26005_BaselineCorridor_OpenLoop2_20260416_00001" 
 )   
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/session.py
+++ b/examples/session.py
@@ -11,7 +11,7 @@ session = UclOpenSession(
     #logging_root_path="../temp_data",
     logging_root_path="C:/UCLOpenDATA/",
     animal_id="M25131/20260414/",
-    session_id="M25131_BaselineCorridor_20260414_Habituation" 
+    session_id="M25131_BaselineCorridor_OpenLoop_20260414_HabituationT" 
 )   
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/session.py
+++ b/examples/session.py
@@ -8,10 +8,10 @@ session = UclOpenSession(
     workflow="main.bonsai",
     commit="",
     repository_url="https://github.com/ucl-open/vr-corridor-2p",
-    logging_root_path="../temp_data",
-    # logging_root_path="C:/UCLOpenDATA/",
-    animal_id="PlaybackTest",
-    session_id="PlaybackTest" 
+    #logging_root_path="../temp_data",
+    logging_root_path="C:/UCLOpenDATA/",
+    animal_id="M25131/20260414/",
+    session_id="M25131_BaselineCorridor_20260414_Habituation" 
 )   
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/session.py
+++ b/examples/session.py
@@ -10,8 +10,8 @@ session = UclOpenSession(
     repository_url="https://github.com/ucl-open/vr-corridor-2p",
     #logging_root_path="../temp_data",
     logging_root_path="C:/UCLOpenDATA/",
-    animal_id="M25131/20260414/",
-    session_id="M25131_BaselineCorridor_OpenLoop_20260414_HabituationT" 
+    animal_id="Plimbo/20260415/",
+    session_id="Plimbo_BaselineCorridor_OL_20260415" 
 )   
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/session.py
+++ b/examples/session.py
@@ -10,8 +10,8 @@ session = UclOpenSession(
     repository_url="https://github.com/ucl-open/vr-corridor-2p",
     #logging_root_path="../temp_data",
     logging_root_path="C:/UCLOpenDATA/",
-    animal_id="M26005/20260416/",
-    session_id="M26005_BaselineCorridor_OpenLoop2_20260416_00001" 
+    animal_id="M26005/20260417/",
+    session_id="M26005_BaselineCorridor_OpenLoopReplay_20260417_00001" 
 )   
 
 def main(path_seed: str = "./local/{schema}.json"):

--- a/examples/task.py
+++ b/examples/task.py
@@ -26,7 +26,7 @@ trial_base = Trial(landmarks=[
                     background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
                     far_landmark=Landmark(size=100, position=200, texture="grey",  reward_valence=0, center_offset=0.0),
                     boundary_threshold=-35.9,
-                    end_trial_threshold=-35.9,#swap to 35.89 during playback
+                    end_trial_threshold=-35.89,#swap to 35.89 during playback
                     movement_visual_gain=halfGain
                     )
 

--- a/examples/task.py
+++ b/examples/task.py
@@ -1,4 +1,6 @@
 import os
+import random
+import copy
 
 from ucl_open_vr_corridor_2p.task import (
     UclOpenVrCorridor2pTaskLogic,
@@ -7,6 +9,10 @@ from ucl_open_vr_corridor_2p.task import (
     Trial,
     Landmark
 )
+
+fullGain =  0.0613 #1cm on wheel = 1cm in vr 
+halfGain = 0.0306 #2cm on wheel = 1cm in vr 
+doubleGain = 0.1226 #1cm on wheel = 2cm in vr 
 
 trial_base = Trial(landmarks=[
                         [Landmark(size=8, position=40, texture="grating_vertical", reward_valence=0)],
@@ -20,11 +26,46 @@ trial_base = Trial(landmarks=[
                     background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
                     far_landmark=Landmark(size=100, position=200, texture="grey",  reward_valence=0, center_offset=0.0),
                     boundary_threshold=-35.9,
-                    end_trial_threshold=-35.89,#swap to 35.89 during playback
-                    movement_visual_gain=0.0613
+                    end_trial_threshold=-35.9,#swap to 35.89 during playback
+                    movement_visual_gain=halfGain
                     )
 
-trial_skip2 = Trial(landmarks=[
+# Swaps the 2nd and 3rd landmark: grating grating plaid plaid
+trial_swap2_3 = Trial(landmarks=[
+                        [Landmark(size=8, position=40, texture="grating_vertical", reward_valence=0)],
+                        [Landmark(size=8, position=80, texture="grating_vertical", reward_valence=0)],
+                        [Landmark(size=8, position=120, texture="plaid", reward_valence=0)],
+                        [Landmark(size=8, position=160, texture="plaid", reward_valence=0)]
+                    ],
+                    background_landmark_left=Landmark(size=200, position=100, texture="BG1", reward_valence=0, center_offset=0.01),
+                    background_landmark_right=Landmark(size=200, position=100, texture="BG2", reward_valence=0, center_offset=0.01),
+                    background_landmark_ceil=Landmark(size=200, position=100, texture="BG3", reward_valence=0, center_offset=0.01),
+                    background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
+                    far_landmark=Landmark(size=100, position=200, texture="grey",  reward_valence=0, center_offset=0.0),
+                    boundary_threshold=-36,
+                    end_trial_threshold=-36,
+                    movement_visual_gain=halfGain
+                    )
+
+# Swaps the 3rd and 4th landmark: grating plaid plaid grating
+trial_swap3_4 = Trial(landmarks=[
+                        [Landmark(size=8, position=40, texture="grating_vertical", reward_valence=0)],
+                        [Landmark(size=8, position=80, texture="plaid", reward_valence=0)],
+                        [Landmark(size=8, position=120, texture="plaid", reward_valence=0)],
+                        [Landmark(size=8, position=160, texture="grating_vertical", reward_valence=0)]
+                    ],
+                    background_landmark_left=Landmark(size=200, position=100, texture="BG1", reward_valence=0, center_offset=0.01),
+                    background_landmark_right=Landmark(size=200, position=100, texture="BG2", reward_valence=0, center_offset=0.01),
+                    background_landmark_ceil=Landmark(size=200, position=100, texture="BG3", reward_valence=0, center_offset=0.01),
+                    background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
+                    far_landmark=Landmark(size=100, position=200, texture="grey",  reward_valence=0, center_offset=0.0),
+                    boundary_threshold=-36,
+                    end_trial_threshold=-36,
+                    movement_visual_gain=halfGain
+                    )
+
+# Omit the 2nd (plaid) landmark 
+trial_omit2 = Trial(landmarks=[
                         [Landmark(size=8, position=40, texture="grating_vertical", reward_valence=0)],
                         [Landmark(size=8, position=120, texture="grating_vertical", reward_valence=0)],
                         [Landmark(size=8, position=160, texture="plaid", reward_valence=0)]
@@ -33,13 +74,15 @@ trial_skip2 = Trial(landmarks=[
                     background_landmark_right=Landmark(size=200, position=100, texture="BG2", reward_valence=0, center_offset=0.01),
                     background_landmark_ceil=Landmark(size=200, position=100, texture="BG3", reward_valence=0, center_offset=0.01),
                     background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
-                    far_landmark=Landmark(size=12, position=200, texture="grey", reward_valence=0, center_offset=0.01), #TODO: change texture to match luminance(?)
-                    boundary_threshold=-35.8,
-                    end_trial_threshold=-35.7,
-                    movement_visual_gain=0.0613
+                    far_landmark=Landmark(size=12, position=200, texture="grey", reward_valence=0, center_offset=0.01), 
+                    boundary_threshold=-36,
+                    end_trial_threshold=-36,
+                    movement_visual_gain=halfGain
                     )
 
-trial_skip3 = Trial(landmarks=[
+
+# Omit the 3rd (grating) landmark 
+trial_omit3 = Trial(landmarks=[
                         [Landmark(size=8, position=40, texture="grating_vertical", reward_valence=0)],
                         [Landmark(size=8, position=80, texture="plaid", reward_valence=0)],
                         [Landmark(size=8, position=160, texture="plaid", reward_valence=0)]
@@ -48,11 +91,80 @@ trial_skip3 = Trial(landmarks=[
                     background_landmark_right=Landmark(size=200, position=100, texture="BG2", reward_valence=0, center_offset=0.01),
                     background_landmark_ceil=Landmark(size=200, position=100, texture="BG3", reward_valence=0, center_offset=0.01),
                     background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
-                    far_landmark=Landmark(size=12, position=200, texture="grey", reward_valence=0, center_offset=0.01), #TODO: change texture to match luminance(?)
-                    boundary_threshold=-35.8,
-                    end_trial_threshold=-35.7,
-                    movement_visual_gain=0.0613
+                    far_landmark=Landmark(size=12, position=200, texture="grey", reward_valence=0, center_offset=0.01), 
+                    boundary_threshold=-36,
+                    end_trial_threshold=-36,
+                    movement_visual_gain=halfGain
                     )
+
+# Omit the 4rd (plaid) landmark
+trial_omit4 = Trial(landmarks=[
+                        [Landmark(size=8, position=40, texture="grating_vertical", reward_valence=0)],
+                        [Landmark(size=8, position=80, texture="plaid", reward_valence=0)],
+                        [Landmark(size=8, position=120, texture="grating_vertical", reward_valence=0)],
+                      
+                    ],
+                    background_landmark_left=Landmark(size=200, position=100, texture="BG1", reward_valence=0, center_offset=0.01),
+                    background_landmark_right=Landmark(size=200, position=100, texture="BG2", reward_valence=0, center_offset=0.01),
+                    background_landmark_ceil=Landmark(size=200, position=100, texture="BG3", reward_valence=0, center_offset=0.01),
+                    background_landmark_floor=Landmark(size=200, position=100, texture="BG4", reward_valence=0, center_offset=0.01),
+                    far_landmark=Landmark(size=100, position=200, texture="grey",  reward_valence=0, center_offset=0.0),
+                    boundary_threshold=-76,
+                    end_trial_threshold=-76,
+                    movement_visual_gain=halfGain
+                    )
+
+# 5 unique test/manipulation trials
+test_trials = [
+    trial_swap2_3, # condition 2
+    trial_swap3_4, # condition 3
+    trial_omit2,   # condition 4
+    trial_omit3,   # condition 5
+    trial_omit4    # condition 6
+]
+
+
+
+full_manipulation_experiment_sequence = []
+
+for i in range(10):
+    
+    # create a shuffle of the 5 tests trials for this specific block
+    current_test_order = copy.deepcopy(test_trials) 
+    random.shuffle(current_test_order)  
+    # 20-trial sequence (3 baseline + 1 test which is repeated 5 times)
+    for test_condition in current_test_order:
+        # add 3 baseline trials
+        for _ in range(3):
+            full_manipulation_experiment_sequence.append(copy.deepcopy(trial_base))
+        # add the test trial
+        full_manipulation_experiment_sequence.append(test_condition) 
+# So now this generates 10 blocks * 20 trials = 200 trials total
+
+
+
+################################################################################
+three_test_trials = [
+    trial_swap2_3, # condition 2
+    trial_omit2,   # condition 3
+    trial_omit3,   # condition 4
+]
+
+three_manipulation_experiment_sequence = []
+
+for i in range(10): #10 blocks 
+    
+    # create a shuffle of the 3 tests trials for this specific block
+    current_three_test_order = copy.deepcopy(three_test_trials) 
+    random.shuffle(current_three_test_order)  
+    # 12-trial sequence (3 baseline + 1 test which is repeated 3 times)
+    for three_test_condition in current_three_test_order:
+        # add 3 baseline trials
+        for _ in range(3):
+            three_manipulation_experiment_sequence.append(copy.deepcopy(trial_base))
+        # add the test trial
+        three_manipulation_experiment_sequence.append(three_test_condition) 
+# So now this generates 10 blocks * 12 trials = 120 trials total
 
 task_logic = UclOpenVrCorridor2pTaskLogic(
     task_parameters=UclOpenVrCorridor2pTaskParameters(
@@ -62,19 +174,15 @@ task_logic = UclOpenVrCorridor2pTaskLogic(
         blocks = [
             Block(
                 randomise_trial_order=False,
+                #available_trials=full_manipulation_experiment_sequence,
+                #available_trials=three_manipulation_experiment_sequence,
                 available_trials=
                 [
                     trial_base,
-                   # trial_skip2,
-                   # trial_base,
-                   # trial_swap23,
-                   # trial_base,
-                   # trial_skip3,
-                   # trial_base
                 ],
             ),
         ],
-        rng_seed=1.1
+        rng_seed=1.1  #needed for open-loop (replay)
     ),
 )
 

--- a/src/DataSchemas/ucl_open_vr_corridor_2p.json
+++ b/src/DataSchemas/ucl_open_vr_corridor_2p.json
@@ -356,15 +356,20 @@
           "title": "FilePath",
           "type": "string"
         },
-        "index": {
-          "title": "Index",
+        "positionIndex": {
+          "title": "PositionIndex",
+          "type": "integer"
+        },
+        "trialIndexIndex": {
+          "title": "TrialIndexIndex",
           "type": "integer"
         }
       },
       "required": [
         "sourceType",
         "filePath",
-        "index"
+        "positionIndex",
+        "trialIndexIndex"
       ],
       "title": "PlaybackMovementSource",
       "type": "object"

--- a/src/Extensions/UclOpenVrCorridor2p.Generated.cs
+++ b/src/Extensions/UclOpenVrCorridor2p.Generated.cs
@@ -1223,7 +1223,9 @@ namespace UclOpenHfVisualDataSchema
     
         private string _filePath;
     
-        private int _index;
+        private int _positionIndex;
+    
+        private int _trialIndexIndex;
     
         public PlaybackMovementSource()
         {
@@ -1233,7 +1235,8 @@ namespace UclOpenHfVisualDataSchema
                 base(other)
         {
             _filePath = other._filePath;
-            _index = other._index;
+            _positionIndex = other._positionIndex;
+            _trialIndexIndex = other._trialIndexIndex;
         }
     
         [Newtonsoft.Json.JsonPropertyAttribute("filePath", Required=Newtonsoft.Json.Required.Always)]
@@ -1249,16 +1252,29 @@ namespace UclOpenHfVisualDataSchema
             }
         }
     
-        [Newtonsoft.Json.JsonPropertyAttribute("index", Required=Newtonsoft.Json.Required.Always)]
-        public int Index
+        [Newtonsoft.Json.JsonPropertyAttribute("positionIndex", Required=Newtonsoft.Json.Required.Always)]
+        public int PositionIndex
         {
             get
             {
-                return _index;
+                return _positionIndex;
             }
             set
             {
-                _index = value;
+                _positionIndex = value;
+            }
+        }
+    
+        [Newtonsoft.Json.JsonPropertyAttribute("trialIndexIndex", Required=Newtonsoft.Json.Required.Always)]
+        public int TrialIndexIndex
+        {
+            get
+            {
+                return _trialIndexIndex;
+            }
+            set
+            {
+                _trialIndexIndex = value;
             }
         }
     
@@ -1279,7 +1295,8 @@ namespace UclOpenHfVisualDataSchema
                 stringBuilder.Append(", ");
             }
             stringBuilder.Append("FilePath = " + _filePath + ", ");
-            stringBuilder.Append("Index = " + _index);
+            stringBuilder.Append("PositionIndex = " + _positionIndex + ", ");
+            stringBuilder.Append("TrialIndexIndex = " + _trialIndexIndex);
             return true;
         }
     }

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -178,7 +178,7 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="io:CsvReader">
-                    <io:FileName>C:/Users/neurogears/source/repos/ucl-open/vr-corridor-2p/temp_data/sub-Plimbo/ses-PlaybackTest_date-2026-04-16T11-49-15/RenderFrameCount/RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/sub-M26005/20260416/ses-M26005_BaselineCorridor_20260416_00001_date-2026-04-16T13-05-41/RenderFrameCount/RenderFrameCount.csv</io:FileName>
                     <io:ListSeparator>,</io:ListSeparator>
                     <io:SkipRows>1</io:SkipRows>
                   </Expression>
@@ -407,7 +407,7 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Devices:SerialDevice.bonsai">
-                    <PortName>COM10</PortName>
+                    <PortName>COM3</PortName>
                     <BaudRate>1000000</BaudRate>
                     <Encoding>utf-8</Encoding>
                     <NewLine>
@@ -714,9 +714,9 @@
                           <LocationY>-1</LocationY>
                           <Layer>1</Layer>
                           <Angle>0</Angle>
-                          <ColorR>1</ColorR>
-                          <ColorG>1</ColorG>
-                          <ColorB>1</ColorB>
+                          <ColorR>0</ColorR>
+                          <ColorG>0</ColorG>
+                          <ColorB>0</ColorB>
                           <ColorA>1</ColorA>
                         </Expression>
                         <Expression xsi:type="rx:PublishSubject">
@@ -840,7 +840,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.448S</rx:DueTime>
+                                  <rx:DueTime>PT0.365S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -906,7 +906,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.251S</rx:DueTime>
+                                  <rx:DueTime>PT0.436S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -996,7 +996,7 @@
                     <Eye>
                       <X>0</X>
                       <Y>-2</Y>
-                      <Z>35.6184235</Z>
+                      <Z>199.9</Z>
                     </Eye>
                     <NearClip>0.1</NearClip>
                     <FarClip>200</FarClip>
@@ -1598,9 +1598,9 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Logging:LogController.bonsai">
-              <SubjectId>Plimbo</SubjectId>
-              <SessionId>PlaybackTest</SessionId>
-              <Path>../temp_data</Path>
+              <SubjectId>M26005/20260416/</SubjectId>
+              <SessionId>M26005_BaselineCorridor_OpenLoop2_20260416_00001</SessionId>
+              <Path>C:/UCLOpenDATA/</Path>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>TrialData</Name>
@@ -1702,7 +1702,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\TrialData\TrialData.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\TrialData\TrialData.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1809,7 +1809,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\MatrixArduino\MatrixArduino.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\MatrixArduino\MatrixArduino.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1934,7 +1934,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\LandmarkChoice\LandmarkChoice.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2053,7 +2053,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\VrPosition\VrPosition.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\VrPosition\VrPosition.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2466,7 +2466,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\RenderFrameCount\RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\RenderFrameCount\RenderFrameCount.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2585,7 +2585,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\QuadState\QuadState.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\QuadState\QuadState.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2699,7 +2699,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\RigSchema\RigSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\RigSchema\RigSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2810,7 +2810,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2921,7 +2921,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\SessionSchema\SessionSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\SessionSchema\SessionSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -5876,7 +5876,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Delay">
-                      <rx:DueTime>PT3.497S</rx:DueTime>
+                      <rx:DueTime>PT3.708S</rx:DueTime>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -5974,7 +5974,7 @@
               <Combinator xsi:type="gl:CreateVector3">
                 <gl:X>0</gl:X>
                 <gl:Y>-2</gl:Y>
-                <gl:Z>35.6184235</gl:Z>
+                <gl:Z>199.9</gl:Z>
               </Combinator>
             </Expression>
             <Expression xsi:type="MulticastSubject">

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -175,7 +175,7 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="io:CsvReader">
-                    <io:FileName>C:/CODE/BONSAI/vr-corridor-2p/temp_data/sub-PlaybackTest/ses-PlaybackTest_date-2026-04-13T10-57-27/RenderFrameCount/RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/sub-M26005/20260414/ses-M26005_BaselineCorridor_20260414_Habituation_date-2026-04-14T11-49-53/RenderFrameCount/RenderFrameCount.csv</io:FileName>
                     <io:ListSeparator>,</io:ListSeparator>
                     <io:SkipRows>1</io:SkipRows>
                   </Expression>
@@ -779,7 +779,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.388S</rx:DueTime>
+                                  <rx:DueTime>PT0.454S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -845,7 +845,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.439S</rx:DueTime>
+                                  <rx:DueTime>PT0.396S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -1537,9 +1537,9 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Logging:LogController.bonsai">
-              <SubjectId>PlaybackTest</SubjectId>
-              <SessionId>PlaybackTest</SessionId>
-              <Path>../temp_data</Path>
+              <SubjectId>M25131/20260414/</SubjectId>
+              <SessionId>M25131_BaselineCorridor_20260414_HabituationT</SessionId>
+              <Path>C:/UCLOpenDATA/</Path>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>MatrixArduino</Name>
@@ -1629,7 +1629,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\MatrixArduino\MatrixArduino.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\MatrixArduino\MatrixArduino.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1754,7 +1754,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\LandmarkChoice\LandmarkChoice.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1873,7 +1873,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\VrPosition\VrPosition.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\VrPosition\VrPosition.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2279,7 +2279,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\RenderFrameCount\RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\RenderFrameCount\RenderFrameCount.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2398,7 +2398,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\QuadState\QuadState.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\QuadState\QuadState.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2512,7 +2512,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\RigSchema\RigSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\RigSchema\RigSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2623,7 +2623,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2734,7 +2734,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>../temp_data\sub-PlaybackTest\ses-PlaybackTest_date-2026-04-13T11-04-32\SessionSchema\SessionSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\SessionSchema\SessionSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -3296,7 +3296,7 @@
                         </Expression>
                         <Expression xsi:type="Subtract">
                           <Operand xsi:type="DoubleProperty">
-                            <Value>-35.89</Value>
+                            <Value>-35.88</Value>
                           </Operand>
                         </Expression>
                         <Expression xsi:type="rx:AsyncSubject">
@@ -3585,7 +3585,7 @@
                         </Expression>
                         <Expression xsi:type="Multiply">
                           <Operand xsi:type="FloatProperty">
-                            <Value>0.0613</Value>
+                            <Value>0.0306</Value>
                           </Operand>
                         </Expression>
                         <Expression xsi:type="Combinator">
@@ -5654,7 +5654,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Delay">
-                      <rx:DueTime>PT3.203S</rx:DueTime>
+                      <rx:DueTime>PT3.708S</rx:DueTime>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -5751,7 +5751,7 @@
               <Combinator xsi:type="gl:CreateVector3">
                 <gl:X>0</gl:X>
                 <gl:Y>-2</gl:Y>
-                <gl:Z>41.6228523</gl:Z>
+                <gl:Z>199.9</gl:Z>
               </Combinator>
             </Expression>
             <Expression xsi:type="MulticastSubject">

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -40,7 +40,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="io:ReadAllText">
-                <io:Path>C:\CODE\BONSAI\vr-corridor-2p\local\UclOpenSession.json</io:Path>
+                <io:Path>..\local\UclOpenSession.json</io:Path>
               </Combinator>
             </Expression>
             <Expression xsi:type="rx:AsyncSubject">
@@ -51,7 +51,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="io:ReadAllText">
-                <io:Path>C:\CODE\BONSAI\vr-corridor-2p\local\UclOpenVrCorridor2pRig.json</io:Path>
+                <io:Path>..\local\UclOpenVrCorridor2pRig.json</io:Path>
               </Combinator>
             </Expression>
             <Expression xsi:type="rx:AsyncSubject">
@@ -62,7 +62,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="io:ReadAllText">
-                <io:Path>C:\CODE\BONSAI\vr-corridor-2p\local\UclOpenVrCorridor2pTaskLogic.json</io:Path>
+                <io:Path>..\local\UclOpenVrCorridor2pTaskLogic.json</io:Path>
               </Combinator>
             </Expression>
             <Expression xsi:type="rx:AsyncSubject">
@@ -349,8 +349,7 @@
                     <PortName>COM3</PortName>
                     <BaudRate>1000000</BaudRate>
                     <Encoding>utf-8</Encoding>
-                    <NewLine>
-</NewLine>
+                    <NewLine />
                     <Parity>None</Parity>
                     <ParityReplace>63</ParityReplace>
                     <DataBits>8</DataBits>

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -178,7 +178,7 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="io:CsvReader">
-                    <io:FileName>C:/UCLOpenDATA/sub-Plimbo/20260415/ses-Plimbo_BaselineCorridor_CL_20260415_date-2026-04-15T09-47-25/RenderFrameCount/RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/Users/neurogears/source/repos/ucl-open/vr-corridor-2p/temp_data/sub-Plimbo/ses-PlaybackTest_date-2026-04-16T11-49-15/RenderFrameCount/RenderFrameCount.csv</io:FileName>
                     <io:ListSeparator>,</io:ListSeparator>
                     <io:SkipRows>1</io:SkipRows>
                   </Expression>
@@ -186,7 +186,7 @@
                     <Name>PlaybackSource</Name>
                   </Expression>
                   <Expression xsi:type="MemberSelector">
-                    <Selector>Index</Selector>
+                    <Selector>PositionIndex</Selector>
                   </Expression>
                   <Expression xsi:type="PropertyMapping">
                     <PropertyMappings>
@@ -201,6 +201,55 @@
                   <Expression xsi:type="scr:ExpressionTransform">
                     <scr:Expression>Convert.ToSingle(it)</scr:Expression>
                   </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>PlaybackSource</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>TrialIndexIndex</Selector>
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="Value" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="Index">
+                    <Operand xsi:type="IntProperty">
+                      <Value>5</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="scr:ExpressionTransform">
+                    <scr:Expression>Convert.ToInt32(it)</scr:Expression>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="rx:Condition">
+                    <Name>ValidTrial</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="WorkflowInput">
+                          <Name>Source1</Name>
+                        </Expression>
+                        <Expression xsi:type="MemberSelector">
+                          <Selector>Item2</Selector>
+                        </Expression>
+                        <Expression xsi:type="GreaterThanOrEqual">
+                          <Operand xsi:type="FloatProperty">
+                            <Value>0</Value>
+                          </Operand>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Item1</Selector>
+                  </Expression>
                   <Expression xsi:type="WorkflowOutput" />
                 </Nodes>
                 <Edges>
@@ -210,11 +259,20 @@
                   <Edge From="4" To="5" Label="Source1" />
                   <Edge From="5" To="6" Label="Source1" />
                   <Edge From="6" To="10" Label="Source1" />
+                  <Edge From="6" To="15" Label="Source1" />
                   <Edge From="7" To="8" Label="Source1" />
                   <Edge From="8" To="9" Label="Source1" />
                   <Edge From="9" To="10" Label="Source2" />
                   <Edge From="10" To="11" Label="Source1" />
-                  <Edge From="11" To="12" Label="Source1" />
+                  <Edge From="11" To="17" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="13" To="14" Label="Source1" />
+                  <Edge From="14" To="15" Label="Source2" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="17" Label="Source2" />
+                  <Edge From="17" To="18" Label="Source1" />
+                  <Edge From="18" To="19" Label="Source1" />
+                  <Edge From="19" To="20" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>
@@ -349,10 +407,11 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Devices:SerialDevice.bonsai">
-                    <PortName>COM3</PortName>
+                    <PortName>COM10</PortName>
                     <BaudRate>1000000</BaudRate>
                     <Encoding>utf-8</Encoding>
-                    <NewLine />
+                    <NewLine>
+</NewLine>
                     <Parity>None</Parity>
                     <ParityReplace>63</ParityReplace>
                     <DataBits>8</DataBits>
@@ -781,7 +840,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.38S</rx:DueTime>
+                                  <rx:DueTime>PT0.448S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -847,7 +906,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.478S</rx:DueTime>
+                                  <rx:DueTime>PT0.251S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -937,7 +996,7 @@
                     <Eye>
                       <X>0</X>
                       <Y>-2</Y>
-                      <Z>41.0649872</Z>
+                      <Z>35.6184235</Z>
                     </Eye>
                     <NearClip>0.1</NearClip>
                     <FarClip>200</FarClip>
@@ -1539,9 +1598,9 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Logging:LogController.bonsai">
-              <SubjectId>Plimbo/20260415/</SubjectId>
-              <SessionId>Plimbo_BaselineCorridor_OL_20260415</SessionId>
-              <Path>C:/UCLOpenDATA/</Path>
+              <SubjectId>Plimbo</SubjectId>
+              <SessionId>PlaybackTest</SessionId>
+              <Path>../temp_data</Path>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>TrialData</Name>
@@ -1643,7 +1702,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\TrialData\TrialData.csv</io:FileName>
+                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\TrialData\TrialData.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1750,7 +1809,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\MatrixArduino\MatrixArduino.csv</io:FileName>
+                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\MatrixArduino\MatrixArduino.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1875,7 +1934,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\LandmarkChoice\LandmarkChoice.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1994,7 +2053,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\VrPosition\VrPosition.csv</io:FileName>
+                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\VrPosition\VrPosition.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2407,7 +2466,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\RenderFrameCount\RenderFrameCount.csv</io:FileName>
+                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\RenderFrameCount\RenderFrameCount.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2526,7 +2585,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\QuadState\QuadState.csv</io:FileName>
+                    <io:FileName>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\QuadState\QuadState.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2640,7 +2699,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\RigSchema\RigSchema.json</p5:Path>
+                      <p5:Path>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\RigSchema\RigSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2751,7 +2810,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
+                      <p5:Path>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2862,7 +2921,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\SessionSchema\SessionSchema.json</p5:Path>
+                      <p5:Path>../temp_data\sub-Plimbo\ses-PlaybackTest_date-2026-04-16T11-57-02\SessionSchema\SessionSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -5817,7 +5876,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Delay">
-                      <rx:DueTime>PT3.221S</rx:DueTime>
+                      <rx:DueTime>PT3.497S</rx:DueTime>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -5915,7 +5974,7 @@
               <Combinator xsi:type="gl:CreateVector3">
                 <gl:X>0</gl:X>
                 <gl:Y>-2</gl:Y>
-                <gl:Z>41.0649872</gl:Z>
+                <gl:Z>35.6184235</gl:Z>
               </Combinator>
             </Expression>
             <Expression xsi:type="MulticastSubject">

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -175,7 +175,7 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="io:CsvReader">
-                    <io:FileName>C:/UCLOpenDATA/sub-M26005/20260414/ses-M26005_BaselineCorridor_20260414_Habituation_date-2026-04-14T11-49-53/RenderFrameCount/RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/sub-Plimbo/20260415/ses-Plimbo_BaselineCorridor_CL_20260415_date-2026-04-15T09-47-25/RenderFrameCount/RenderFrameCount.csv</io:FileName>
                     <io:ListSeparator>,</io:ListSeparator>
                     <io:SkipRows>1</io:SkipRows>
                   </Expression>
@@ -349,7 +349,8 @@
                     <PortName>COM3</PortName>
                     <BaudRate>1000000</BaudRate>
                     <Encoding>utf-8</Encoding>
-                    <NewLine />
+                    <NewLine>
+</NewLine>
                     <Parity>None</Parity>
                     <ParityReplace>63</ParityReplace>
                     <DataBits>8</DataBits>
@@ -652,9 +653,9 @@
                           <LocationY>-1</LocationY>
                           <Layer>1</Layer>
                           <Angle>0</Angle>
-                          <ColorR>0</ColorR>
-                          <ColorG>0</ColorG>
-                          <ColorB>0</ColorB>
+                          <ColorR>1</ColorR>
+                          <ColorG>1</ColorG>
+                          <ColorB>1</ColorB>
                           <ColorA>1</ColorA>
                         </Expression>
                         <Expression xsi:type="rx:PublishSubject">
@@ -778,7 +779,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.454S</rx:DueTime>
+                                  <rx:DueTime>PT0.38S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -844,7 +845,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.396S</rx:DueTime>
+                                  <rx:DueTime>PT0.478S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -934,7 +935,7 @@
                     <Eye>
                       <X>0</X>
                       <Y>-2</Y>
-                      <Z>0</Z>
+                      <Z>41.0649872</Z>
                     </Eye>
                     <NearClip>0.1</NearClip>
                     <FarClip>200</FarClip>
@@ -1536,8 +1537,8 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Logging:LogController.bonsai">
-              <SubjectId>M25131/20260414/</SubjectId>
-              <SessionId>M25131_BaselineCorridor_20260414_HabituationT</SessionId>
+              <SubjectId>Plimbo/20260415/</SubjectId>
+              <SessionId>Plimbo_BaselineCorridor_OL_20260415</SessionId>
               <Path>C:/UCLOpenDATA/</Path>
             </Expression>
             <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p1:Trial">
@@ -1640,7 +1641,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\TrialData\TrialData.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1747,7 +1748,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\MatrixArduino\MatrixArduino.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\MatrixArduino\MatrixArduino.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1872,7 +1873,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\LandmarkChoice\LandmarkChoice.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1991,7 +1992,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\VrPosition\VrPosition.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\VrPosition\VrPosition.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2397,7 +2398,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\RenderFrameCount\RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\RenderFrameCount\RenderFrameCount.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2516,7 +2517,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\QuadState\QuadState.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\QuadState\QuadState.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2630,7 +2631,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\RigSchema\RigSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\RigSchema\RigSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2741,7 +2742,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2852,7 +2853,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\SessionSchema\SessionSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260415/\ses-Plimbo_BaselineCorridor_OL_20260415_date-2026-04-15T10-26-41\SessionSchema\SessionSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -3422,7 +3423,7 @@
                         </Expression>
                         <Expression xsi:type="Subtract">
                           <Operand xsi:type="DoubleProperty">
-                            <Value>-35.88</Value>
+                            <Value>-35.89</Value>
                           </Operand>
                         </Expression>
                         <Expression xsi:type="rx:AsyncSubject">
@@ -5780,7 +5781,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Delay">
-                      <rx:DueTime>PT3.708S</rx:DueTime>
+                      <rx:DueTime>PT3.221S</rx:DueTime>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -5878,7 +5879,7 @@
               <Combinator xsi:type="gl:CreateVector3">
                 <gl:X>0</gl:X>
                 <gl:Y>-2</gl:Y>
-                <gl:Z>199.9</gl:Z>
+                <gl:Z>41.0649872</gl:Z>
               </Combinator>
             </Expression>
             <Expression xsi:type="MulticastSubject">

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -178,7 +178,7 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="io:CsvReader">
-                    <io:FileName>C:/UCLOpenDATA/sub-M26005/20260416/ses-M26005_BaselineCorridor_20260416_00001_date-2026-04-16T13-05-41/RenderFrameCount/RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/sub-Plimbo/20260417/ses-Playback_date-2026-04-17T08-02-30/RenderFrameCount/RenderFrameCount.csv</io:FileName>
                     <io:ListSeparator>,</io:ListSeparator>
                     <io:SkipRows>1</io:SkipRows>
                   </Expression>
@@ -840,7 +840,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.365S</rx:DueTime>
+                                  <rx:DueTime>PT0.452S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -906,7 +906,7 @@
                               </Expression>
                               <Expression xsi:type="Combinator">
                                 <Combinator xsi:type="rx:Delay">
-                                  <rx:DueTime>PT0.436S</rx:DueTime>
+                                  <rx:DueTime>PT0.426S</rx:DueTime>
                                 </Combinator>
                               </Expression>
                               <Expression xsi:type="Combinator">
@@ -996,7 +996,7 @@
                     <Eye>
                       <X>0</X>
                       <Y>-2</Y>
-                      <Z>199.9</Z>
+                      <Z>8.659797</Z>
                     </Eye>
                     <NearClip>0.1</NearClip>
                     <FarClip>200</FarClip>
@@ -1598,8 +1598,8 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Logging:LogController.bonsai">
-              <SubjectId>M26005/20260416/</SubjectId>
-              <SessionId>M26005_BaselineCorridor_OpenLoop2_20260416_00001</SessionId>
+              <SubjectId>Plimbo/20260417/</SubjectId>
+              <SessionId>Playback</SessionId>
               <Path>C:/UCLOpenDATA/</Path>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
@@ -1702,7 +1702,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\TrialData\TrialData.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\TrialData\TrialData.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1809,7 +1809,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\MatrixArduino\MatrixArduino.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\MatrixArduino\MatrixArduino.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -1934,7 +1934,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\LandmarkChoice\LandmarkChoice.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2053,7 +2053,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\VrPosition\VrPosition.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\VrPosition\VrPosition.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2466,7 +2466,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\RenderFrameCount\RenderFrameCount.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\RenderFrameCount\RenderFrameCount.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2585,7 +2585,7 @@
                     <Property Name="Selector" />
                   </Expression>
                   <Expression xsi:type="io:CsvWriter">
-                    <io:FileName>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\QuadState\QuadState.csv</io:FileName>
+                    <io:FileName>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\QuadState\QuadState.csv</io:FileName>
                     <io:Append>false</io:Append>
                     <io:Overwrite>false</io:Overwrite>
                     <io:Suffix>None</io:Suffix>
@@ -2699,7 +2699,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\RigSchema\RigSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\RigSchema\RigSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2810,7 +2810,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\TaskLogicSchema\TaskLogicSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -2921,7 +2921,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p5:JsonWriter">
-                      <p5:Path>C:/UCLOpenDATA/\sub-M26005/20260416/\ses-M26005_BaselineCorridor_OpenLoop2_20260416_00001_date-2026-04-16T13-44-30\SessionSchema\SessionSchema.json</p5:Path>
+                      <p5:Path>C:/UCLOpenDATA/\sub-Plimbo/20260417/\ses-Playback_date-2026-04-17T08-07-05\SessionSchema\SessionSchema.json</p5:Path>
                       <p5:Suffix>None</p5:Suffix>
                       <p5:Overwrite>false</p5:Overwrite>
                     </Combinator>
@@ -5636,6 +5636,11 @@
                           </Workflow>
                         </Expression>
                         <Expression xsi:type="Unit" />
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:DelaySubscription">
+                            <rx:DueTime>PT0.5S</rx:DueTime>
+                          </Combinator>
+                        </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>LickDetection</Name>
                         </Expression>
@@ -5800,29 +5805,30 @@
                         <Edge From="2" To="3" Label="Source1" />
                         <Edge From="3" To="4" Label="Source1" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="27" Label="Source1" />
+                        <Edge From="5" To="28" Label="Source1" />
                         <Edge From="6" To="7" Label="Source1" />
                         <Edge From="7" To="8" Label="Source1" />
-                        <Edge From="8" To="27" Label="Source2" />
-                        <Edge From="9" To="11" Label="Source1" />
-                        <Edge From="10" To="11" Label="Source2" />
-                        <Edge From="11" To="12" Label="Source1" />
+                        <Edge From="8" To="9" Label="Source1" />
+                        <Edge From="9" To="28" Label="Source2" />
+                        <Edge From="10" To="12" Label="Source1" />
+                        <Edge From="11" To="12" Label="Source2" />
                         <Edge From="12" To="13" Label="Source1" />
-                        <Edge From="13" To="24" Label="Source1" />
-                        <Edge From="14" To="21" Label="Source1" />
-                        <Edge From="15" To="16" Label="Source1" />
+                        <Edge From="13" To="14" Label="Source1" />
+                        <Edge From="14" To="25" Label="Source1" />
+                        <Edge From="15" To="22" Label="Source1" />
                         <Edge From="16" To="17" Label="Source1" />
                         <Edge From="17" To="18" Label="Source1" />
                         <Edge From="18" To="19" Label="Source1" />
                         <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source2" />
-                        <Edge From="21" To="22" Label="Source1" />
+                        <Edge From="20" To="21" Label="Source1" />
+                        <Edge From="21" To="22" Label="Source2" />
                         <Edge From="22" To="23" Label="Source1" />
-                        <Edge From="23" To="24" Label="Source2" />
-                        <Edge From="24" To="25" Label="Source1" />
+                        <Edge From="23" To="24" Label="Source1" />
+                        <Edge From="24" To="25" Label="Source2" />
                         <Edge From="25" To="26" Label="Source1" />
-                        <Edge From="26" To="27" Label="Source3" />
-                        <Edge From="27" To="28" Label="Source1" />
+                        <Edge From="26" To="27" Label="Source1" />
+                        <Edge From="27" To="28" Label="Source3" />
+                        <Edge From="28" To="29" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -5876,7 +5882,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Delay">
-                      <rx:DueTime>PT3.708S</rx:DueTime>
+                      <rx:DueTime>PT3.64S</rx:DueTime>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -5974,7 +5980,7 @@
               <Combinator xsi:type="gl:CreateVector3">
                 <gl:X>0</gl:X>
                 <gl:Y>-2</gl:Y>
-                <gl:Z>199.9</gl:Z>
+                <gl:Z>8.659797</gl:Z>
               </Combinator>
             </Expression>
             <Expression xsi:type="MulticastSubject">

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -12,8 +12,8 @@
                  xmlns:res="clr-namespace:Bonsai.Resources;assembly=Bonsai.System"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
-                 xmlns:p4="clr-namespace:UclOpen.Core;assembly=UclOpen.Core"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:p4="clr-namespace:UclOpen.Core;assembly=UclOpen.Core"
                  xmlns:p5="clr-namespace:UclOpen.Logging;assembly=UclOpen.Logging"
                  xmlns:p6="clr-namespace:OpenTK;assembly=OpenTK"
                  xmlns:wie="clr-namespace:Bonsai.Windows.Input;assembly=Bonsai.Windows.Input"
@@ -349,8 +349,7 @@
                     <PortName>COM3</PortName>
                     <BaudRate>1000000</BaudRate>
                     <Encoding>utf-8</Encoding>
-                    <NewLine>
-</NewLine>
+                    <NewLine />
                     <Parity>None</Parity>
                     <ParityReplace>63</ParityReplace>
                     <DataBits>8</DataBits>
@@ -1540,6 +1539,125 @@
               <SubjectId>M25131/20260414/</SubjectId>
               <SessionId>M25131_BaselineCorridor_20260414_HabituationT</SessionId>
               <Path>C:/UCLOpenDATA/</Path>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p1:Trial">
+              <rx:Name>TrialData</rx:Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>MatrixArduino</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Seconds</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:WithLatestFrom" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="harp:CreateTimestamped" />
+            </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>LogData</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="ExternalizedMapping">
+                    <Property Name="Name" />
+                    <Property Name="Extension" />
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>FormatFileName</Name>
+                    <Description>Generates a log filename based on the input timestamp.</Description>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>PathPrefix</Name>
+                        </Expression>
+                        <Expression xsi:type="WorkflowInput">
+                          <Name>Source1</Name>
+                        </Expression>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="Value" DisplayName="Name" Description="The base name of the log file." />
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="StringProperty">
+                            <Value>TrialData</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="p4:StripSubstring" />
+                        </Expression>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="Value" DisplayName="Extension" Description="The file extension" />
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="StringProperty">
+                            <Value>csv</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Zip" />
+                        </Expression>
+                        <Expression xsi:type="Format">
+                          <Format>{0}\{1}\{2}.{3}</Format>
+                          <Selector>Item1,Item2,Item3,Item4</Selector>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="9" Label="Source1" />
+                        <Edge From="1" To="3" Label="Source1" />
+                        <Edge From="2" To="3" Label="Source2" />
+                        <Edge From="3" To="4" Label="Source1" />
+                        <Edge From="4" To="5" Label="Source1" />
+                        <Edge From="4" To="9" Label="Source3" />
+                        <Edge From="5" To="9" Label="Source2" />
+                        <Edge From="6" To="7" Label="Source1" />
+                        <Edge From="7" To="8" Label="Source1" />
+                        <Edge From="8" To="9" Label="Source4" />
+                        <Edge From="9" To="10" Label="Source1" />
+                        <Edge From="10" To="11" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FileName" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="ExternalizedMapping">
+                    <Property Name="Selector" />
+                  </Expression>
+                  <Expression xsi:type="io:CsvWriter">
+                    <io:FileName>C:/UCLOpenDATA/\sub-M25131/20260414/\ses-M25131_BaselineCorridor_20260414_HabituationT_date-2026-04-14T13-01-13\LandmarkChoice\LandmarkChoice.csv</io:FileName>
+                    <io:Append>false</io:Append>
+                    <io:Overwrite>false</io:Overwrite>
+                    <io:Suffix>None</io:Suffix>
+                    <io:IncludeHeader>true</io:IncludeHeader>
+                    <io:Selector>it</io:Selector>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="5" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="5" Label="Source2" />
+                  <Edge From="4" To="5" Label="Source3" />
+                  <Edge From="5" To="6" Label="Source1" />
+                </Edges>
+              </Workflow>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>MatrixArduino</Name>
@@ -2761,14 +2879,14 @@
             <Edge From="6" To="7" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source3" />
-            <Edge From="10" To="11" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="10" To="13" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
             <Edge From="13" To="14" Label="Source1" />
-            <Edge From="14" To="17" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source2" />
-            <Edge From="17" To="18" Label="Source1" />
+            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
+            <Edge From="19" To="20" Label="Source1" />
             <Edge From="20" To="23" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source2" />
@@ -2778,30 +2896,35 @@
             <Edge From="27" To="28" Label="Source1" />
             <Edge From="28" To="29" Label="Source2" />
             <Edge From="29" To="30" Label="Source1" />
-            <Edge From="30" To="32" Label="Source1" />
-            <Edge From="31" To="32" Label="Source2" />
-            <Edge From="33" To="35" Label="Source1" />
+            <Edge From="30" To="31" Label="Source1" />
+            <Edge From="32" To="35" Label="Source1" />
+            <Edge From="33" To="34" Label="Source1" />
             <Edge From="34" To="35" Label="Source2" />
             <Edge From="35" To="36" Label="Source1" />
-            <Edge From="36" To="39" Label="Source1" />
-            <Edge From="37" To="38" Label="Source1" />
-            <Edge From="38" To="39" Label="Source2" />
-            <Edge From="39" To="40" Label="Source1" />
-            <Edge From="40" To="41" Label="Source1" />
+            <Edge From="36" To="38" Label="Source1" />
+            <Edge From="37" To="38" Label="Source2" />
+            <Edge From="39" To="41" Label="Source1" />
+            <Edge From="40" To="41" Label="Source2" />
+            <Edge From="41" To="42" Label="Source1" />
             <Edge From="42" To="45" Label="Source1" />
             <Edge From="43" To="44" Label="Source1" />
             <Edge From="44" To="45" Label="Source2" />
             <Edge From="45" To="46" Label="Source1" />
             <Edge From="46" To="47" Label="Source1" />
-            <Edge From="48" To="49" Label="Source1" />
+            <Edge From="48" To="51" Label="Source1" />
             <Edge From="49" To="50" Label="Source1" />
-            <Edge From="50" To="51" Label="Source1" />
+            <Edge From="50" To="51" Label="Source2" />
+            <Edge From="51" To="52" Label="Source1" />
             <Edge From="52" To="53" Label="Source1" />
-            <Edge From="53" To="54" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
+            <Edge From="55" To="56" Label="Source1" />
             <Edge From="56" To="57" Label="Source1" />
-            <Edge From="57" To="58" Label="Source1" />
             <Edge From="58" To="59" Label="Source1" />
+            <Edge From="59" To="60" Label="Source1" />
+            <Edge From="60" To="61" Label="Source1" />
+            <Edge From="62" To="63" Label="Source1" />
+            <Edge From="63" To="64" Label="Source1" />
+            <Edge From="64" To="65" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -3185,6 +3308,9 @@
                   </Expression>
                   <Expression xsi:type="rx:AsyncSubject">
                     <Name>Trial</Name>
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>TrialData</Name>
                   </Expression>
                   <Expression xsi:type="GroupWorkflow">
                     <Name>ResetPosition</Name>
@@ -5667,48 +5793,49 @@
                 <Edges>
                   <Edge From="0" To="1" Label="Source1" />
                   <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="7" To="8" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
                   <Edge From="8" To="9" Label="Source1" />
                   <Edge From="9" To="10" Label="Source1" />
-                  <Edge From="10" To="32" Label="Source1" />
-                  <Edge From="11" To="12" Label="Source1" />
-                  <Edge From="12" To="14" Label="Source1" />
-                  <Edge From="13" To="14" Label="Source2" />
-                  <Edge From="14" To="15" Label="Source1" />
-                  <Edge From="15" To="32" Label="Source2" />
-                  <Edge From="16" To="17" Label="Source1" />
+                  <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="11" To="33" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="13" To="15" Label="Source1" />
+                  <Edge From="14" To="15" Label="Source2" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="33" Label="Source2" />
                   <Edge From="17" To="18" Label="Source1" />
                   <Edge From="18" To="19" Label="Source1" />
-                  <Edge From="19" To="32" Label="Source3" />
-                  <Edge From="20" To="21" Label="Source1" />
+                  <Edge From="19" To="20" Label="Source1" />
+                  <Edge From="20" To="33" Label="Source3" />
                   <Edge From="21" To="22" Label="Source1" />
                   <Edge From="22" To="23" Label="Source1" />
-                  <Edge From="23" To="32" Label="Source4" />
-                  <Edge From="24" To="25" Label="Source1" />
+                  <Edge From="23" To="24" Label="Source1" />
+                  <Edge From="24" To="33" Label="Source4" />
                   <Edge From="25" To="26" Label="Source1" />
                   <Edge From="26" To="27" Label="Source1" />
-                  <Edge From="27" To="32" Label="Source5" />
-                  <Edge From="28" To="29" Label="Source1" />
+                  <Edge From="27" To="28" Label="Source1" />
+                  <Edge From="28" To="33" Label="Source5" />
                   <Edge From="29" To="30" Label="Source1" />
                   <Edge From="30" To="31" Label="Source1" />
-                  <Edge From="31" To="32" Label="Source6" />
-                  <Edge From="32" To="34" Label="Source1" />
-                  <Edge From="33" To="34" Label="Source2" />
-                  <Edge From="34" To="35" Label="Source1" />
-                  <Edge From="35" To="47" Label="Source1" />
-                  <Edge From="36" To="43" Label="Source1" />
-                  <Edge From="37" To="38" Label="Source1" />
+                  <Edge From="31" To="32" Label="Source1" />
+                  <Edge From="32" To="33" Label="Source6" />
+                  <Edge From="33" To="35" Label="Source1" />
+                  <Edge From="34" To="35" Label="Source2" />
+                  <Edge From="35" To="36" Label="Source1" />
+                  <Edge From="36" To="48" Label="Source1" />
+                  <Edge From="37" To="44" Label="Source1" />
                   <Edge From="38" To="39" Label="Source1" />
-                  <Edge From="39" To="43" Label="Source2" />
-                  <Edge From="40" To="41" Label="Source1" />
+                  <Edge From="39" To="40" Label="Source1" />
+                  <Edge From="40" To="44" Label="Source2" />
                   <Edge From="41" To="42" Label="Source1" />
-                  <Edge From="42" To="43" Label="Source3" />
-                  <Edge From="43" To="44" Label="Source1" />
+                  <Edge From="42" To="43" Label="Source1" />
+                  <Edge From="43" To="44" Label="Source3" />
                   <Edge From="44" To="45" Label="Source1" />
                   <Edge From="45" To="46" Label="Source1" />
-                  <Edge From="46" To="47" Label="Source2" />
-                  <Edge From="47" To="48" Label="Source1" />
+                  <Edge From="46" To="47" Label="Source1" />
+                  <Edge From="47" To="48" Label="Source2" />
                   <Edge From="48" To="49" Label="Source1" />
+                  <Edge From="49" To="50" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>

--- a/src/main.bonsai
+++ b/src/main.bonsai
@@ -139,6 +139,9 @@
             <Expression xsi:type="rx:AsyncSubject">
               <Name>TaskLogicParameters</Name>
             </Expression>
+            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p1:Trial">
+              <rx:Name>TrialData</rx:Name>
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>RigSchema</Name>
             </Expression>
@@ -285,22 +288,22 @@
             <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
             <Edge From="12" To="13" Label="Source1" />
-            <Edge From="14" To="15" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
-            <Edge From="19" To="20" Label="Source1" />
-            <Edge From="20" To="24" Label="Source1" />
-            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="20" To="21" Label="Source1" />
+            <Edge From="21" To="25" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source2" />
-            <Edge From="24" To="25" Label="Source1" />
+            <Edge From="23" To="24" Label="Source1" />
+            <Edge From="24" To="25" Label="Source2" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
             <Edge From="27" To="28" Label="Source1" />
             <Edge From="28" To="29" Label="Source1" />
             <Edge From="29" To="30" Label="Source1" />
             <Edge From="30" To="31" Label="Source1" />
+            <Edge From="31" To="32" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -1540,8 +1543,8 @@
               <SessionId>Plimbo_BaselineCorridor_OL_20260415</SessionId>
               <Path>C:/UCLOpenDATA/</Path>
             </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p1:Trial">
-              <rx:Name>TrialData</rx:Name>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>TrialData</Name>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>MatrixArduino</Name>
@@ -2289,15 +2292,22 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>CurrentPosition</Name>
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CurrentTrialIndex</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:CombineLatest" />
+            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:WithLatestFrom" />
             </Expression>
             <Expression xsi:type="scr:ExpressionTransform">
               <scr:Expression>new(
   it.Item1 as RenderFrameCount,
-  it.Item2.X as PositionX,
-  it.Item2.Y as PositionY,
-  it.Item2.Z as PositionZ
+  it.Item2.Item1.X as PositionX,
+  it.Item2.Item1.Y as PositionY,
+  it.Item2.Item1.Z as PositionZ,
+  it.Item2.Item2 as TrialIndex
 )</scr:Expression>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
@@ -2903,33 +2913,60 @@
             <Edge From="35" To="36" Label="Source1" />
             <Edge From="36" To="38" Label="Source1" />
             <Edge From="37" To="38" Label="Source2" />
-            <Edge From="39" To="41" Label="Source1" />
-            <Edge From="40" To="41" Label="Source2" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="42" To="45" Label="Source1" />
+            <Edge From="39" To="43" Label="Source1" />
+            <Edge From="40" To="42" Label="Source1" />
+            <Edge From="41" To="42" Label="Source2" />
+            <Edge From="42" To="43" Label="Source2" />
             <Edge From="43" To="44" Label="Source1" />
-            <Edge From="44" To="45" Label="Source2" />
+            <Edge From="44" To="47" Label="Source1" />
             <Edge From="45" To="46" Label="Source1" />
-            <Edge From="46" To="47" Label="Source1" />
-            <Edge From="48" To="51" Label="Source1" />
-            <Edge From="49" To="50" Label="Source1" />
-            <Edge From="50" To="51" Label="Source2" />
+            <Edge From="46" To="47" Label="Source2" />
+            <Edge From="47" To="48" Label="Source1" />
+            <Edge From="48" To="49" Label="Source1" />
+            <Edge From="50" To="53" Label="Source1" />
             <Edge From="51" To="52" Label="Source1" />
-            <Edge From="52" To="53" Label="Source1" />
+            <Edge From="52" To="53" Label="Source2" />
+            <Edge From="53" To="54" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
-            <Edge From="55" To="56" Label="Source1" />
             <Edge From="56" To="57" Label="Source1" />
+            <Edge From="57" To="58" Label="Source1" />
             <Edge From="58" To="59" Label="Source1" />
-            <Edge From="59" To="60" Label="Source1" />
             <Edge From="60" To="61" Label="Source1" />
+            <Edge From="61" To="62" Label="Source1" />
             <Edge From="62" To="63" Label="Source1" />
-            <Edge From="63" To="64" Label="Source1" />
             <Edge From="64" To="65" Label="Source1" />
+            <Edge From="65" To="66" Label="Source1" />
+            <Edge From="66" To="67" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p6:Vector3">
         <rx:Name>CurrentPosition</rx:Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>TrialData</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="IntProperty">
+          <Value>1</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:Accumulate" />
+      <Expression xsi:type="Subtract">
+        <Operand xsi:type="IntProperty">
+          <Value>1</Value>
+        </Operand>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="IntProperty">
+          <Value>-1</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Merge" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>CurrentTrialIndex</Name>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>TaskLogicParameters</Name>
@@ -5933,42 +5970,48 @@
       <Edge From="7" To="8" Label="Source1" />
       <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="10" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
       <Edge From="12" To="13" Label="Source1" />
-      <Edge From="12" To="27" Label="Source1" />
-      <Edge From="13" To="14" Label="Source1" />
-      <Edge From="13" To="16" Label="Source1" />
-      <Edge From="13" To="25" Label="Source1" />
-      <Edge From="13" To="28" Label="Source1" />
       <Edge From="14" To="15" Label="Source1" />
-      <Edge From="15" To="23" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
       <Edge From="16" To="17" Label="Source1" />
       <Edge From="17" To="18" Label="Source1" />
-      <Edge From="18" To="19" Label="Source1" />
-      <Edge From="18" To="20" Label="Source1" />
-      <Edge From="19" To="20" Label="Source2" />
+      <Edge From="19" To="20" Label="Source1" />
+      <Edge From="19" To="34" Label="Source1" />
       <Edge From="20" To="21" Label="Source1" />
+      <Edge From="20" To="23" Label="Source1" />
+      <Edge From="20" To="32" Label="Source1" />
+      <Edge From="20" To="35" Label="Source1" />
       <Edge From="21" To="22" Label="Source1" />
-      <Edge From="22" To="23" Label="Source2" />
+      <Edge From="22" To="30" Label="Source1" />
       <Edge From="23" To="24" Label="Source1" />
+      <Edge From="24" To="25" Label="Source1" />
       <Edge From="25" To="26" Label="Source1" />
+      <Edge From="25" To="27" Label="Source1" />
+      <Edge From="26" To="27" Label="Source2" />
+      <Edge From="27" To="28" Label="Source1" />
       <Edge From="28" To="29" Label="Source1" />
-      <Edge From="29" To="31" Label="Source1" />
-      <Edge From="30" To="31" Label="Source2" />
-      <Edge From="31" To="32" Label="Source1" />
+      <Edge From="29" To="30" Label="Source2" />
+      <Edge From="30" To="31" Label="Source1" />
       <Edge From="32" To="33" Label="Source1" />
-      <Edge From="34" To="35" Label="Source1" />
       <Edge From="35" To="36" Label="Source1" />
+      <Edge From="36" To="38" Label="Source1" />
+      <Edge From="37" To="38" Label="Source2" />
+      <Edge From="38" To="39" Label="Source1" />
       <Edge From="39" To="40" Label="Source1" />
-      <Edge From="40" To="41" Label="Source1" />
       <Edge From="41" To="42" Label="Source1" />
-      <Edge From="43" To="44" Label="Source1" />
-      <Edge From="44" To="45" Label="Source1" />
-      <Edge From="45" To="46" Label="Source1" />
-      <Edge From="47" To="49" Label="Source1" />
-      <Edge From="48" To="49" Label="Source2" />
-      <Edge From="49" To="51" Label="Source1" />
-      <Edge From="50" To="51" Label="Source2" />
+      <Edge From="42" To="43" Label="Source1" />
+      <Edge From="46" To="47" Label="Source1" />
+      <Edge From="47" To="48" Label="Source1" />
+      <Edge From="48" To="49" Label="Source1" />
+      <Edge From="50" To="51" Label="Source1" />
+      <Edge From="51" To="52" Label="Source1" />
+      <Edge From="52" To="53" Label="Source1" />
+      <Edge From="54" To="56" Label="Source1" />
+      <Edge From="55" To="56" Label="Source2" />
+      <Edge From="56" To="58" Label="Source1" />
+      <Edge From="57" To="58" Label="Source2" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/ucl_open_vr_corridor_2p/rig.py
+++ b/src/ucl_open_vr_corridor_2p/rig.py
@@ -30,7 +30,8 @@ class MouseWheelMovementSource(MovementSource):
 class PlaybackMovementSource(MovementSource):
     source_type: Literal["playback"]
     file_path: str
-    index: int
+    position_index: int
+    trial_index_index: int
 
 class UclOpenVrCorridor2pRig(BaseSchema):
     version: Literal[__semver__] = __semver__


### PR DESCRIPTION
This PR addresses issue #27 and adds a further data column to RenderFrame logging that keeps track of the current trial. This allows playback to limit itself to data recorded after trial logic has started. Additionally, this adds a short buffer for checking trial boundary conditions, so that slight offsets in playback sync do not immediately restart a trial during playback.